### PR TITLE
Fix multi_causal_forest predict with newdata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Suggests:
     testthat (>= 2.1.0),
     DiagrammeR
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 LinkingTo:
     Rcpp,
     BH

--- a/R/multi_causal_forest.R
+++ b/R/multi_causal_forest.R
@@ -257,13 +257,22 @@ multi_causal_forest <- function(X, Y, W,
 predict.multi_causal_forest <- function(object, newdata = NULL, ...) {
   forests <- object$forests
 
+  # A `grf` prediction object is a data frame with columns `predictions`
+  # and other estimates. This transforms the list of data frames for each
+  # forest (action k) to a list of each estimate (with each data frame containing
+  # n.actions columns).
   predictions <- sapply(forests, function(forest) {
     predict(forest, newdata = newdata, ...)
   })
-  outputs <- rownames(predictions)
+  outputs <- if(is.null(rownames(predictions))) {
+    "predictions"
+  } else {
+    rownames(predictions)
+  }
+  predictions <- matrix(predictions, ncol = length(object$forests))
 
-  out <- lapply(outputs, function(output) {
-    values <- as.data.frame(predictions[output, ])
+  out <- lapply(1:nrow(predictions), function(row) {
+    values <- as.data.frame(predictions[row, ])
     colnames(values) <- names(forests)
     values
   })

--- a/tests/testthat/test_multi_causal_forest.R
+++ b/tests/testthat/test_multi_causal_forest.R
@@ -6,6 +6,7 @@ test_that("everything runs", {
   Y <- runif(n)
   W <- sample(1:d, n, replace = TRUE)
 
+  # Some simple smoke tests
   mcf <- multi_causal_forest(X, Y, W)
   predict(mcf)
   conditional_means(mcf)
@@ -18,7 +19,18 @@ test_that("everything runs", {
 
   multi_causal_forest(X, Y, W, W.hat = matrix(1 / 3, n, d))
 
-  expect_equal(1, 1)
+  #
+  predictions.oob <- predict(mcf)
+  predictions <- predict(mcf, X)
+  predictions.var <- predict(mcf, X, estimate.variance = TRUE)
+
+  expect_equal(length(predictions.oob), 3) # grf returns 3 estimates
+  expect_equal(length(predictions), 1) # grf returns 1 estimate
+  expect_equal(length(predictions.var), 2) # grf returns 2 estimates
+
+  expect_equal(ncol(predictions.oob$predictions), d)
+  expect_equal(ncol(predictions$predictions), d)
+  expect_equal(ncol(predictions.var$predictions), d)
 })
 
 test_that("predictions have not changed", {


### PR DESCRIPTION
This fixes a bug where the output returned from `grf` was lost due to a bad reshape when `newdata` is not `NULL`, as pointed out by @mollyow and @halflearned

Working now:
```R
n <- 100
p <- 10
data <- gen_data_mapl(n, p)

X <- data$X
Y <- data$Y
W <- data$action

multi.forest <- multi_causal_forest(X, Y, W, seed = 123)
head(predict(multi.forest)$predictions)

head(predict(multi.forest, X)$predictions)

head(predict(multi.forest, X, estimate.variance = TRUE)$var)
```
