### PR TITLE
Fix depth 0 base case in tree_search

### DIFF
--- a/src/tree_search.cpp
+++ b/src/tree_search.cpp
@@ -260,8 +260,11 @@ std::unique_ptr<Node> find_best_split(const std::vector<flat_set>& sorted_sets,
                                       int level,
                                       const Data* data,
                                       std::vector<std::vector<double>>& sum_array) {
-  // if at the parent of a leaf node we can compute the optimal action for both leaves
-  if (level == 1) {
+  if (level == 0) {
+    // this base case will only be hit if `find_best_split` is called directly with level = 0
+    return level_zero_learning(sorted_sets, data);
+  } else if (level == 1) {
+    // if at the parent of a leaf node we can compute the optimal action for both leaves
     return level_one_learning(sorted_sets, data, sum_array);
   // else continue the recursion
   } else {

--- a/tests/testthat/test_policy_tree.R
+++ b/tests/testthat/test_policy_tree.R
@@ -76,6 +76,36 @@ test_that("solver bindings run", {
 })
 
 
+test_that("exact tree search finds the correct depth 0 tree", {
+  depth <- 0
+  n <- 100
+  p <- sample(1:10, 1)
+  d <- sample(1:5, 1)
+  # Continuous X
+  X <- matrix(rnorm(n * p), n, p)
+  Y <- matrix(rnorm(n * d), n, d)
+
+  best.action <- which.max(colMeans(Y))
+  best.reward <- max(colMeans(Y))
+  tree <- policy_tree(X, Y, depth = depth)
+  action.tree <- predict(tree, X)
+  reward.tree <- mean(Y[cbind(1:n, action.tree)])
+
+  expect_equal(reward.tree, best.reward)
+  expect_true(all(best.action == action.tree))
+
+  # Discrete X
+  X <- matrix(sample(10:20, n * p, replace = TRUE), n, p)
+
+  tree <- policy_tree(X, Y, depth = depth)
+  action.tree <- predict(tree, X)
+  reward.tree <- mean(Y[cbind(1:n, action.tree)])
+
+  expect_equal(reward.tree, best.reward)
+  expect_true(all(best.action == action.tree))
+})
+
+
 test_that("exact tree search finds the correct depth 1 tree", {
   depth <- 1
   n <- 250


### PR DESCRIPTION
Add a base case that was removed for simplicity because `find_best_split` would never hit a recursion with `level = 0`. Added now in case a user directly calls tree search with a depth 0 tree (same as just the column max's)


Closes #3 (thanks @halflearned)