### PR TITLE
Remove the optional num.trees.orthog argument

### DIFF
--- a/R/multi_causal_forest.R
+++ b/R/multi_causal_forest.R
@@ -20,8 +20,6 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param num.trees.orthog Number of trees used in Y.hat and W.hat estimation (optional).
-#'  Default is max(50, num.trees / 4).
 #' @param sample.weights (experimental) Weights given to each sample in estimation.
 #'                       If NULL, each observation receives the same weight.
 #'                       Note: To avoid introducing confounding, weights should be
@@ -106,7 +104,6 @@ multi_causal_forest <- function(X, Y, W,
                                 Y.hat = NULL,
                                 W.hat = NULL,
                                 num.trees = 2000,
-                                num.trees.orthog = max(50, num.trees / 4),
                                 sample.weights = NULL,
                                 clusters = NULL,
                                 equalize.cluster.weights = FALSE,
@@ -136,7 +133,7 @@ multi_causal_forest <- function(X, Y, W,
 
   # Unconditional mean
   args.orthog <- list(X = X,
-                     num.trees = num.trees.orthog,
+                     num.trees = max(50, num.trees / 4),
                      sample.weights = sample.weights,
                      clusters = clusters,
                      equalize.cluster.weights = equalize.cluster.weights,

--- a/man/multi_causal_forest.Rd
+++ b/man/multi_causal_forest.Rd
@@ -11,7 +11,6 @@ multi_causal_forest(
   Y.hat = NULL,
   W.hat = NULL,
   num.trees = 2000,
-  num.trees.orthog = max(50, num.trees/4),
   sample.weights = NULL,
   clusters = NULL,
   equalize.cluster.weights = FALSE,
@@ -53,9 +52,6 @@ these are estimated using a k separate regression forests. Default is NULL.}
 \item{num.trees}{Number of trees grown in the forest. Note: Getting accurate
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
-
-\item{num.trees.orthog}{Number of trees used in Y.hat and W.hat estimation (optional).
-Default is max(50, num.trees / 4).}
 
 \item{sample.weights}{(experimental) Weights given to each sample in estimation.
 If NULL, each observation receives the same weight.


### PR DESCRIPTION
Maintain harmony with `grf` interface, if the user wants more trees in nuisance component estimation then this can be done trough `Y.hat` or `W.hat`.