### PR TITLE
Fix treatment vector categories bug

### DIFF
--- a/R/multi_causal_forest-scores.R
+++ b/R/multi_causal_forest-scores.R
@@ -19,9 +19,9 @@ double_robust_scores.multi_causal_forest <- function(object, ...) {
   n.treatments <- ncol(object$W.hat)
   treatment.names <- colnames(object$W.hat)
 
-  # grep since the treatment data structures are ordered columnwise from 1..n.treatments,
+  # The treatment data structures are ordered columnwise from 1..n.treatments,
   # but the original W vector may be encoded arbitrarily (eg "0, 1, 2" , "A, B, C", etc.)
-  observed.treatment <- sapply(object$W.orig, function(w) grep(w, treatment.names))
+  observed.treatment <- sapply(object$W.orig, function(w) match(w, treatment.names))
   observed.treatment.idx <- cbind(1:n.obs, observed.treatment)
 
   YY <- matrix(0, n.obs, n.treatments)


### PR DESCRIPTION
This fixes a case when `multi_causal_forest` is input a treatment vector W that may cause multiple partial matches with `grep`, like for example `W = c("0", "1000", "2000")`.

This bug would not have resulted in corrupted estimates as the double robust score calculation would have failed with an error. 

Closes #21 (Thank you @halflearned)