### PR TITLE
Remove binary installs form `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ cache: packages
 warnings_are_errors: true
 r_check_args: --as-cran --run-donttest
 
-r_binary_packages:
-  - knitr
-  - rmarkdown
-
 r_packages:
+  # Online documentation
   - pkgdown
-  - BH # Boost header files
 
 branches:
   only:


### PR DESCRIPTION
With R 4.0 these break due to tidyverse dependencies. Sacrifice build time and just install everything from source instead.