### PR TITLE
Extend input check by checking if numeric

### DIFF
--- a/R/policy_tree.R
+++ b/R/policy_tree.R
@@ -32,24 +32,30 @@
 #' @importFrom Rcpp evalCpp
 #' @importFrom utils type.convert
 policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
-  X <- as.matrix(X)
-  Gamma <- as.matrix(Gamma)
   n.features <- ncol(X)
   n.actions <- ncol(Gamma)
   n.obs <- nrow(X)
+  valid.classes <- c("matrix", "data.frame")
 
+  if (!inherits(X, valid.classes) || !inherits(Gamma, valid.classes)) {
+    stop(paste("Currently the only supported data input types are:",
+               "`matrix`, `data.frame`"))
+  }
+  if (!is.numeric(as.matrix(X))) {
+    stop("The feature matrix X must be numeric")
+  }
+  if (!is.numeric(as.matrix(Gamma))) {
+    stop("The reward matrix Gamma must be numeric")
+  }
   if (any(is.na(X))) {
     stop("Covariate matrix X contains missing values.")
   }
-
   if (any(is.na(Gamma))) {
     stop("Gamma matrix contains missing values.")
   }
-
   if (depth < 0 ) {
     stop("`depth` cannot be negative.")
   }
-
   if (n.obs != nrow(Gamma)) {
     stop("X and Gamma does not have the same number of rows")
   }
@@ -64,7 +70,7 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
     columns <- make.names(1:ncol(X))
   }
 
-  nodes <- tree_search_rcpp(X, Gamma, depth, split.step)
+  nodes <- tree_search_rcpp(as.matrix(X), as.matrix(Gamma), depth, split.step)
   tree = list(nodes = nodes)
 
   tree[["depth"]] <- depth

--- a/R/policy_tree.R
+++ b/R/policy_tree.R
@@ -107,10 +107,18 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' predict(tree, features)
 #' }
 predict.policy_tree <- function(object, newdata, ...) {
-  # if nrow = 1:
-  if (is.null(dim(newdata))) {
-    newdata <- matrix(newdata, nrow = 1)
+  valid.classes <- c("matrix", "data.frame")
+  if (!inherits(newdata, valid.classes)) {
+    stop(paste("Currently the only supported data input types are:",
+               "`matrix`, `data.frame`"))
   }
+  if (!is.numeric(as.matrix(newdata))) {
+    stop("The feature matrix X must be numeric")
+  }
+  if (any(is.na(newdata))) {
+    stop("Covariate matrix X contains missing values.")
+  }
+
   tree <- object
   if (tree$n.features != ncol(newdata)) {
     stop("This tree was trained with ", tree$n.features, " variables. Provided: ", ncol(newdata))

--- a/tests/testthat/test_policy_tree.R
+++ b/tests/testthat/test_policy_tree.R
@@ -67,7 +67,7 @@ test_that("solver bindings run", {
   p <- capture.output(print(pt))
 
   p1 <- predict(pt, X)
-  p2 <- predict(pt, X[1, ])
+  p2 <- predict(pt, X[1, , drop = FALSE])
 
   p <- capture.output(print(pt))
   plot(pt)


### PR DESCRIPTION
Add some extra input checks to `policy_tree`:

* Check that input is numeric (i.e. not strings/factors)
* Check that input class belongs to matrix or data.frame instead of immediately doing as.matrix.

If you want to predict at a single sample you need `predict(tree, features[1, , drop=FALSE])`