### PR TITLE
Add a `multi_causal_forest` treatment decomposition example to vignette

### DIFF
--- a/vignettes/policytree.Rmd
+++ b/vignettes/policytree.Rmd
@@ -129,6 +129,64 @@ reward.policy <- mean((2 * piX - 1) * data$tau[-train])
 reward.policy
 ```
 
+# Multi causal forest treatment estimates and baselines
+
+This is a worked example of how `multi_causal_forest` treatment estimates can be decomposed (and interpreted) to target the parameter you are interested in. Consider the following DGP:
+
+
+```{r}
+n <- 10000
+p <- 5
+X <- matrix(rnorm(n * p), n, p)
+W <- sample(c("A", "B", "C"), n, replace = TRUE)
+tauB <- X[, 2]
+tauC <- 2 * X[, 2]
+Y <- X[, 1] + tauB * (W == "B") + tauC * (W == "C") + rnorm(n)
+mcf <- multi_causal_forest(X, Y, W)
+tau.mcf <- predict(mcf)$predictions
+```
+
+Recall that `multi_causal_forest` simply fits one `causal_forest` per treament, with the same nuisance component $Y.hat = m(x) = E[Y | X]$ for each forest. Each forest returns a treatment estimate  $\tau_k(x) = \frac{\mu_k(x) - m(x)}{1 - e_k(x)}$, where $\mu_k(x) = E[Y | X, W=W_k]$ is the conditional mean of arm $k$ and $e_k(x)$ is the assignment probability of arm $k$.
+
+In the above DGP
+
+$m(x) = X1 + 1/3 X2 + 1/3 \cdot 2X2 = X1 + X2$
+
+$\mu_B = X1 + X2$
+
+$\mu_C = X1 + 2X2$
+
+$e_B(x) = e_C(x) = 1/3$
+
+Which gives the multi causal forest predictions:
+
+$\tau_B(X) = (X1 + X2 - (X1 + X2)) / (1 - 1/3) = 0$
+
+$\tau_C(X) = (X1 + X2 - (X1 + 2X2)) / (1 - 1/3) = 3/2 X2$
+
+I.e, the estimated $\tau_B(x)$ will be zero because of the centering step. The estimate for $\tau_C(X)$ should be scaled by $4/3$ in order to be compared with ground truth ($2 X2)$:
+
+```{r}
+plot(X[, 2], tauB, type = "l", lwd = 1)
+points(X[, 2], tau.mcf[, "B"], col = 2, cex = 0.1)
+lines(X[, 2], tauC, lwd = 3)
+points(X[, 2], tau.mcf[, "C"], col = 3, cex = 0.1)
+points(X[, 2], 4/3 * tau.mcf[, "C"], col = 4, cex = 0.1)
+legend = c("treatment B", "tau.mcf[,'B']",
+           "treatment C", "tau.mcf[,'C']", "4/3 tau.mcf[,'C'] ")
+legend("topleft", legend = legend,
+       col = c(1, 2, 1, 3, 4),
+       pch = c(NA, 19, NA, 19, 19),
+       bg = "transparent",
+       bty = "n",
+       lwd = c(1, NA, 3, NA, NA))
+```
+
+Naturally the following regression coefficient is close to $4/3$
+```{r}
+lm(tauC ~ tau.mcf[, "C"] - 1)
+```
+
 # Gauging the runtime of tree search
 
 The amortized runtime of the exact tree search is $O(p^k n^k (log n + d) + pnlog n)$ where $p$ is the number of features, $d$ the number of treatments, $n$ the number of observations, and $k \geq 1$ the tree depth.


### PR DESCRIPTION
The R documentation is perhaps not the best place for this, so in this vignette example we work through what `multi_causal_forest` estimates in an example DGP.

https://grf-labs.github.io/policytree/articles/policytree.html#multi-causal-forest-treatment-estimates-and-baselines-1