### PR TITLE
Simplify a C++ binding signature

### DIFF
--- a/r-package/src/Rcppbindings.cpp
+++ b/r-package/src/Rcppbindings.cpp
@@ -15,6 +15,7 @@
   along with policytree. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------*/
 #include <queue>
+#include <Rcpp.h>
 
 #include "tree_search.h"
 
@@ -44,7 +45,7 @@ Rcpp::List tree_search_rcpp(const Rcpp::NumericMatrix& X,
   size_t num_rows = X.rows();
   size_t num_cols_x = X.cols();
   size_t num_cols_y = Y.cols();
-  const Data* data = new Data(X, Y, num_rows, num_cols_x, num_cols_y);
+  const Data* data = new Data(X.begin(), Y.begin(), num_rows, num_cols_x, num_cols_y);
 
   std::unique_ptr<Node> root = tree_search(depth, split_step, data);
 

--- a/r-package/src/tree_search.h
+++ b/r-package/src/tree_search.h
@@ -17,6 +17,7 @@
 #ifndef TREE_SEARCH_H
 #define TREE_SEARCH_H
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <vector>

--- a/r-package/src/tree_search.h
+++ b/r-package/src/tree_search.h
@@ -21,24 +21,20 @@
 #include <stdexcept>
 #include <vector>
 
-#include <Rcpp.h>
-
 // #define DEBUG
 
 const double INF = std::numeric_limits<double>::infinity();
 
-
 // Data class for column major storage
 class Data {
 public:
-  Data(const Rcpp::NumericMatrix& data_x,
-       const Rcpp::NumericMatrix& data_y,
+  Data(const double* data_x,
+       const double* data_y,
        size_t num_rows,
        size_t num_cols_x,
        size_t num_cols_y) :
-  num_rows(num_rows), num_cols_x(num_cols_x), num_cols_y(num_cols_y) {
-    this->data_x = data_x.begin();
-    this->data_y = data_y.begin();
+  num_rows(num_rows), data_x(data_x), data_y(data_y),
+  num_cols_x(num_cols_x), num_cols_y(num_cols_y) {
   }
 
   double get_x(size_t row, size_t col) const {


### PR DESCRIPTION
This is purely aesthetic change. Only the C++ binding file needs to know about Rcpp, `tree_search.h` should be agnostic wrt that.

`tree_search.cpp` can be integrated with whatever language that has pointer access to arrays in column major storage.