### PR TITLE
Add an optional `leaf.labels` argument to policy_tree plot

### DIFF
--- a/r-package/R/policy_tree-plot.R
+++ b/r-package/R/policy_tree-plot.R
@@ -85,7 +85,7 @@ export_graphviz <- function(tree) {
 #'
 #' @method plot policy_tree
 #' @examples
-#' Plot a policy_tree object
+#' # Plot a policy_tree object
 #' \dontrun{
 #' n <- 250
 #' p <- 10

--- a/r-package/R/policy_tree-plot.R
+++ b/r-package/R/policy_tree-plot.R
@@ -10,8 +10,10 @@ create_dot_body <- function(tree, index = 1) {
   # Leaf case: print label only
   if (node$is_leaf) {
     action <- node$action
-    line_label <- paste(index - 1, ' [shape=box,style=filled,color=".7 .3 1.0" , label="leaf node', "
-      action = ", action, '"];')
+    line_label <- paste(index - 1,
+                        ' [shape=box,style=filled,color=".7 .3 1.0" , label="',
+                        tree$leaf.labels[action],
+                        '"];')
     return(line_label)
   }
 
@@ -80,7 +82,8 @@ export_graphviz <- function(tree) {
 }
 
 #' Plot a policy_tree tree object.
-#' @param x The tree to plot
+#' @param x The tree to plot.
+#' @param leaf.labels An optional character vector of leaf labels for each treatment.
 #' @param ... Additional arguments (currently ignored).
 #'
 #' @method plot policy_tree
@@ -97,16 +100,30 @@ export_graphviz <- function(tree) {
 #' tree <- policy_tree(X, Gamma.matrix, depth = 2)
 #' plot(tree)
 #'
+#' # Provide optional names for the treatment names in each leaf node
+#' # `action.names` is by default the column names of the reward matrix
+#' plot(tree, leaf.labels = tree$action.names)
+#' # Providing a custom character vector
+#' plot(tree, leaf.labels = c("treatment A", "treatment B", "placebo C"))
+#'
 #' # Saving a plot in a vectorized SVG format can be done with the `DiagrammeRsvg` package.
 #' install.packages("DiagrammeRsvg")
 #' tree.plot = plot(tree)
 #' cat(DiagrammeRsvg::export_svg(tree.plot), file = 'plot.svg')
 #' }
 #' @export
-plot.policy_tree <- function(x, ...) {
+plot.policy_tree <- function(x, leaf.labels = NULL, ...) {
   if (!requireNamespace("DiagrammeR", quietly = TRUE)) {
     stop("Package \"DiagrammeR\" must be installed to plot trees.")
   }
+
+  n.actions <- x$n.actions
+  if (is.null(leaf.labels)) {
+    leaf.labels <- paste("leaf node\n action =", 1:n.actions)
+  } else if (length(leaf.labels) != n.actions) {
+    stop("If provided, `leaf.labels` should be a vector with leaf labels for each treatment 1,..,K")
+  }
+  x$leaf.labels <- leaf.labels
 
   dot_file <- export_graphviz(x)
   DiagrammeR::grViz(dot_file)

--- a/r-package/man/plot.policy_tree.Rd
+++ b/r-package/man/plot.policy_tree.Rd
@@ -4,10 +4,12 @@
 \alias{plot.policy_tree}
 \title{Plot a policy_tree tree object.}
 \usage{
-\method{plot}{policy_tree}(x, ...)
+\method{plot}{policy_tree}(x, leaf.labels = NULL, ...)
 }
 \arguments{
-\item{x}{The tree to plot}
+\item{x}{The tree to plot.}
+
+\item{leaf.labels}{An optional character vector of leaf labels for each treatment.}
 
 \item{...}{Additional arguments (currently ignored).}
 }
@@ -26,6 +28,12 @@ multi.forest <- multi_causal_forest(X = X, Y = Y, W = W)
 Gamma.matrix <- double_robust_scores(multi.forest)
 tree <- policy_tree(X, Gamma.matrix, depth = 2)
 plot(tree)
+
+# Provide optional names for the treatment names in each leaf node
+# `action.names` is by default the column names of the reward matrix
+plot(tree, leaf.labels = tree$action.names)
+# Providing a custom character vector
+plot(tree, leaf.labels = c("treatment A", "treatment B", "placebo C"))
 
 # Saving a plot in a vectorized SVG format can be done with the `DiagrammeRsvg` package.
 install.packages("DiagrammeRsvg")

--- a/r-package/man/plot.policy_tree.Rd
+++ b/r-package/man/plot.policy_tree.Rd
@@ -15,7 +15,7 @@
 Plot a policy_tree tree object.
 }
 \examples{
-Plot a policy_tree object
+# Plot a policy_tree object
 \dontrun{
 n <- 250
 p <- 10


### PR DESCRIPTION
Add the optional argument `leaf.labels` allowing for custom treatment labels in tree plots:

Default plot
```R
n <- 250
p <- 10
X <- matrix(rnorm(n * p), n, p)
W <- sample(c("A", "B", "C"), n, replace = TRUE)
Y <- X[, 1] + X[, 2] * (W == "B") + X[, 3] * (W == "C") + runif(n)
multi.forest <- multi_causal_forest(X = X, Y = Y, W = W)
Gamma.matrix <- double_robust_scores(multi.forest)

plot(tree)
```
![Screen Shot 2020-10-21 at 14 16 18](https://user-images.githubusercontent.com/7185264/96788345-37691880-13a8-11eb-8032-ea05f8273740.png)

With `leaf.labels` provided
```R
plot(tree, leaf.labels = c("treatment A", "treatment B", "placebo C"))
```
![Screen Shot 2020-10-21 at 14 16 35](https://user-images.githubusercontent.com/7185264/96788417-549de700-13a8-11eb-9e20-fc9c25f70941.png)


(closes #57)