### PR TITLE
Install an earlier version of `pkgdown` for online docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       before_deploy:
         - cp ../README.md .
         - cp ../releases/CHANGELOG.md .
-        - Rscript -e 'install.packages("pkgdown")'
+        - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/pkgdown/pkgdown_1.5.1.tar.gz", repos = NULL, type = "source")'
         - Rscript -e 'install.packages(getwd(), repos = NULL, type = "source")'
         - Rscript -e 'pkgdown::build_site()'
         - cp pkgdown/favicon/* docs/


### PR DESCRIPTION
The current version has broken dependencies, this one appear more stable.