### PR TITLE
Add light input checks to `multi_causal_forest`

### DIFF
--- a/r-package/R/multi_causal_forest.R
+++ b/r-package/R/multi_causal_forest.R
@@ -123,7 +123,13 @@ multi_causal_forest <- function(X, Y, W,
                                 orthog.boosting = FALSE,
                                 num.threads = NULL,
                                 seed = runif(1, 0, .Machine$integer.max)) {
-
+  if (!inherits(X, c("matrix", "data.frame", "dgCMatrix"))) {
+    stop(paste("Currently the only supported data input types are:",
+               "`matrix`, `data.frame`, `dgCMatrix`"))
+  }
+  if (length(W) != nrow(X) || any(is.na(W))) {
+    stop("Invalid W input.")
+  }
   # All parameters except W.hat (and W) is the same for each grf::causal_forest
   treatments <- sort(unique(W))
   treatment.names <- as.character(treatments)


### PR DESCRIPTION
All parameters are passed onto GRF functions which has their own input checks - but these two arguments are used intermediately and should be validated before use.