### PR TITLE
Redefine `split.step` to skip samples and not unique values

### DIFF
--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -19,8 +19,8 @@
 #' @param depth The depth of the fitted tree. Default is 2.
 #' @param split.step An optional approximation parameter (integer above zero), the number of possible splits
 #'  to consider when performing tree search. split.step = 1 (default) considers every possible split, split.step = 10
-#'  considers splitting at every 10'th distinct value and will yield a substantial speedup for densely packed
-#'  continuous data. Manually rounding or re-encoding continuous covariates with very high cardinality in a
+#'  considers splitting at every 10'th sample and may yield a substantial speedup for dense features.
+#'  Manually rounding or re-encoding continuous covariates with very high cardinality in a
 #'  problem specific manner allows for finer-grained control of the accuracy/runtime tradeoff and may in some cases
 #'  be the preferred approach over this option.
 #'

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -86,6 +86,9 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
   if (n.obs != nrow(Gamma)) {
     stop("X and Gamma does not have the same number of rows")
   }
+  if (as.integer(split.step) != split.step || split.step < 1) {
+    stop("`split.step` should be an integer greater than or equal to 1.")
+  }
 
   action.names <- colnames(Gamma)
   if (is.null(action.names)) {

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -15,8 +15,8 @@ policy_tree(X, Gamma, depth = 2, split.step = 1)
 
 \item{split.step}{An optional approximation parameter (integer above zero), the number of possible splits
 to consider when performing tree search. split.step = 1 (default) considers every possible split, split.step = 10
-considers splitting at every 10'th distinct value and will yield a substantial speedup for densely packed
-continuous data. Manually rounding or re-encoding continuous covariates with very high cardinality in a
+considers splitting at every 10'th sample and may yield a substantial speedup for dense features.
+Manually rounding or re-encoding continuous covariates with very high cardinality in a
 problem specific manner allows for finer-grained control of the accuracy/runtime tradeoff and may in some cases
 be the preferred approach over this option.}
 }

--- a/r-package/policytree/src/tree_search.cpp
+++ b/r-package/policytree/src/tree_search.cpp
@@ -154,11 +154,11 @@ std::unique_ptr<Node> level_one_learning(const std::vector<flat_set>& sorted_set
         break;
       }
       auto next_value = it->get_value(p);
+      split_counter += 1;
       if (value == next_value) {
         continue;
       }
-      split_counter += 1;
-      if (split_counter == split_step) { // only split at every `split_step`th point
+      if (split_counter >= split_step) { // only split at every `split_step`th sample
         split_counter = 0;
       } else {
         continue;
@@ -244,7 +244,7 @@ std::unique_ptr<Node> level_one_learning(const std::vector<flat_set>& sorted_set
  * @param level: The tree depth
  * @param split_step An optional approximation parameter, the number of possible splits to consider when
  *  performing tree search. split_step = 1 considers every possible split, split_step = 10
- *  considers splitting at every 10'th distinct value and will yield a substantial speedup.
+ *  considers splitting at every 10'th sample and may give a substantial speedup on dense features.
  * @param data: The data class
  * @param sum_array: A global zero initialized (num_rewards) x (num_points + 1)
  *  array which is used to calculate cumulative rewards.
@@ -317,11 +317,11 @@ std::unique_ptr<Node> find_best_split(const std::vector<flat_set>& sorted_sets,
           left_sorted_sets[j].insert(point_bk); // O(log n)
         }
         auto next = right_sorted_sets[p].cbegin(); // O(1)
+        split_counter += 1;
         if (point_bk.get_value(p) >= next->get_value(p)) { // are the values the same then skip
           continue;
         }
-        split_counter += 1;
-        if (split_counter == split_step) { // only split at every `split_step`th point
+        if (split_counter >= split_step) { // only split at every `split_step`th sample
           split_counter = 0;
         } else {
           continue;


### PR DESCRIPTION
See issue #55:

This implements the suggested resolution: `split.step` now skips observations instead of unique values.