### PR TITLE
Add "node.id" option to predict

### DIFF
--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -1,7 +1,7 @@
 #' Fit a policy with exact tree search
 #'
 #' Finds the optimal (maximizing the sum of rewards) depth L tree by exhaustive search. If the optimal
-#' action is the same in both the left and right leaf of a node, the node is pruned.
+#' action is the same in both the left and right node.id of a node, the node is pruned.
 #'
 #' The amortized runtime of the exact tree search is \eqn{O(p^k n^k (log n + d) + pnlog n)} where p is the number of features, d the number of treatments, n the number of observations, and \eqn{k \geq 1} the tree depth.
 #'
@@ -120,12 +120,12 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' @param object policy_tree object
 #' @param newdata A data frame with features
 #' @param type The type of prediction required, "action" is the action id and
-#'  "leaf" is the integer id of the leaf node the samples falls into. Default is "action".
+#'  "node.id" is the integer id of the leaf node the samples falls into. Default is "action".
 #' @param ... Additional arguments (currently ignored).
 #'
-#' @return A vector of predictions. For type = "action" each element is an integer from 1 to d where d is
-#'  the number of columns in the reward matrix. For type = "leaf" each element is an integer corresponding
-#'  to the node id the sample falls into.
+#' @return A vector of predictions. For type = "action.id" each element is an integer from 1 to d where d is
+#'  the number of columns in the reward matrix. For type = "node.id" each element is an integer corresponding
+#'  to the node the sample falls into.
 #' @export
 #'
 #' @method predict policy_tree
@@ -149,15 +149,15 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' predicted <- predict(tree, X)
 #'
 #' # Predict the leaf assigned to each sample.
-#' leaf.id <- predict(tree, X, type = "leaf")
+#' node.id <- predict(tree, X, type = "node.id")
 #' # Reshape to a list of samples per leaf node with `split`.
-#' samples.per.leaf <- split(1:n, leaf.id)
+#' samples.per.leaf <- split(1:n, node.id)
 #'
 #' plot(X[, 1], X[, 2], col = predicted)
 #' legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
 #' abline(0, -1, lty = 2)
 #' }
-predict.policy_tree <- function(object, newdata, type = c("action", "leaf"), ...) {
+predict.policy_tree <- function(object, newdata, type = c("action.id", "node.id"), ...) {
   type <- match.arg(type)
   valid.classes <- c("matrix", "data.frame")
   if (!inherits(newdata, valid.classes)) {
@@ -178,7 +178,7 @@ predict.policy_tree <- function(object, newdata, type = c("action", "leaf"), ...
 
   ret <- tree_search_rcpp_predict(tree[["_tree_array"]], as.matrix(newdata))
 
-  if (type == "action") {
+  if (type == "action.id") {
     return (ret[, 1])
   } else {
     return (ret[, 2])

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -1,7 +1,7 @@
 #' Fit a policy with exact tree search
 #'
 #' Finds the optimal (maximizing the sum of rewards) depth L tree by exhaustive search. If the optimal
-#' action is the same in both the left and right node.id of a node, the node is pruned.
+#' action is the same in both the left and right leaf of a node, the node is pruned.
 #'
 #' The amortized runtime of the exact tree search is \eqn{O(p^k n^k (log n + d) + pnlog n)} where p is the number of features, d the number of treatments, n the number of observations, and \eqn{k \geq 1} the tree depth.
 #'

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -119,8 +119,8 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' Predict values based on fitted policy_tree object.
 #' @param object policy_tree object
 #' @param newdata A data frame with features
-#' @param type The type of prediction required, "action" is the action id and
-#'  "node.id" is the integer id of the leaf node the samples falls into. Default is "action".
+#' @param type The type of prediction required, "action.id" is the action id and
+#'  "node.id" is the integer id of the leaf node the samples falls into. Default is "action.id".
 #' @param ... Additional arguments (currently ignored).
 #'
 #' @return A vector of predictions. For type = "action.id" each element is an integer from 1 to d where d is

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -120,7 +120,7 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' @param object policy_tree object
 #' @param newdata A data frame with features
 #' @param type The type of prediction required, "action.id" is the action id and
-#'  "node.id" is the integer id of the leaf node the samples falls into. Default is "action.id".
+#'  "node.id" is the integer id of the leaf node the sample falls into. Default is "action.id".
 #' @param ... Additional arguments (currently ignored).
 #'
 #' @return A vector of predictions. For type = "action.id" each element is an integer from 1 to d where d is

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -124,8 +124,8 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' @param ... Additional arguments (currently ignored).
 #'
 #' @return A vector of predictions. For type = "action" each element is an integer from 1 to d where d is
-#'  the number of columns in the reward matrix. For type = "leaf" each element is an integer from
-#'  1 to the number of leaves.
+#'  the number of columns in the reward matrix. For type = "leaf" each element is an integer corresponding
+#'  to the node id the sample falls into.
 #' @export
 #'
 #' @method predict policy_tree
@@ -181,8 +181,7 @@ predict.policy_tree <- function(object, newdata, type = c("action", "leaf"), ...
   if (type == "action") {
     return (ret[, 1])
   } else {
-    # Relabel the node ids to consecutive integers 1 to num.leaves
-    return (as.numeric(as.factor(ret[, 2])))
+    return (ret[, 2])
   }
 
 }

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -119,10 +119,13 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' Predict values based on fitted policy_tree object.
 #' @param object policy_tree object
 #' @param newdata A data frame with features
+#' @param type The type of prediction required, "action" is the action id and
+#'  "leaf" is the integer id of the leaf node the samples falls into. Default is "action".
 #' @param ... Additional arguments (currently ignored).
 #'
-#' @return A vector of predictions. Each element is an integer from 1 to d where d is
-#'  the number of columns in the reward matrix.
+#' @return A vector of predictions. For type = "action" each element is an integer from 1 to d where d is
+#'  the number of columns in the reward matrix. For type = "leaf" each element is an integer from
+#'  1 to the number of leaves.
 #' @export
 #'
 #' @method predict policy_tree
@@ -145,11 +148,17 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1) {
 #' # Predict treatment assignment.
 #' predicted <- predict(tree, X)
 #'
+#' # Predict the leaf assigned to each sample.
+#' leaf.id <- predict(tree, X, type = "leaf")
+#' # Reshape to a list of samples per leaf node with `split`.
+#' samples.per.leaf <- split(1:n, leaf.id)
+#'
 #' plot(X[, 1], X[, 2], col = predicted)
 #' legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
 #' abline(0, -1, lty = 2)
 #' }
-predict.policy_tree <- function(object, newdata, ...) {
+predict.policy_tree <- function(object, newdata, type = c("action", "leaf"), ...) {
+  type <- match.arg(type)
   valid.classes <- c("matrix", "data.frame")
   if (!inherits(newdata, valid.classes)) {
     stop(paste("Currently the only supported data input types are:",
@@ -167,5 +176,13 @@ predict.policy_tree <- function(object, newdata, ...) {
     stop("This tree was trained with ", tree$n.features, " variables. Provided: ", ncol(newdata))
   }
 
-  tree_search_rcpp_predict(tree[["_tree_array"]], as.matrix(newdata))
+  ret <- tree_search_rcpp_predict(tree[["_tree_array"]], as.matrix(newdata))
+
+  if (type == "action") {
+    return (ret[, 1])
+  } else {
+    # Relabel the node ids to consecutive integers 1 to num.leaves
+    return (as.numeric(as.factor(ret[, 2])))
+  }
+
 }

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -25,7 +25,7 @@ A policy_tree object.
 }
 \description{
 Finds the optimal (maximizing the sum of rewards) depth L tree by exhaustive search. If the optimal
-action is the same in both the left and right leaf of a node, the node is pruned.
+action is the same in both the left and right node.id of a node, the node is pruned.
 }
 \details{
 The amortized runtime of the exact tree search is \eqn{O(p^k n^k (log n + d) + pnlog n)} where p is the number of features, d the number of treatments, n the number of observations, and \eqn{k \geq 1} the tree depth.

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -25,7 +25,7 @@ A policy_tree object.
 }
 \description{
 Finds the optimal (maximizing the sum of rewards) depth L tree by exhaustive search. If the optimal
-action is the same in both the left and right node.id of a node, the node is pruned.
+action is the same in both the left and right leaf of a node, the node is pruned.
 }
 \details{
 The amortized runtime of the exact tree search is \eqn{O(p^k n^k (log n + d) + pnlog n)} where p is the number of features, d the number of treatments, n the number of observations, and \eqn{k \geq 1} the tree depth.

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -11,8 +11,8 @@
 
 \item{newdata}{A data frame with features}
 
-\item{type}{The type of prediction required, "action" is the action id and
-"node.id" is the integer id of the leaf node the samples falls into. Default is "action".}
+\item{type}{The type of prediction required, "action.id" is the action id and
+"node.id" is the integer id of the leaf node the samples falls into. Default is "action.id".}
 
 \item{...}{Additional arguments (currently ignored).}
 }

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -12,7 +12,7 @@
 \item{newdata}{A data frame with features}
 
 \item{type}{The type of prediction required, "action.id" is the action id and
-"node.id" is the integer id of the leaf node the samples falls into. Default is "action.id".}
+"node.id" is the integer id of the leaf node the sample falls into. Default is "action.id".}
 
 \item{...}{Additional arguments (currently ignored).}
 }

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -18,8 +18,8 @@
 }
 \value{
 A vector of predictions. For type = "action" each element is an integer from 1 to d where d is
-the number of columns in the reward matrix. For type = "leaf" each element is an integer from
-1 to the number of leaves.
+the number of columns in the reward matrix. For type = "leaf" each element is an integer corresponding
+to the node id the sample falls into.
 }
 \description{
 Predict values based on fitted policy_tree object.

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -4,7 +4,7 @@
 \alias{predict.policy_tree}
 \title{Predict method for policy_tree}
 \usage{
-\method{predict}{policy_tree}(object, newdata, type = c("action", "leaf"), ...)
+\method{predict}{policy_tree}(object, newdata, type = c("action.id", "node.id"), ...)
 }
 \arguments{
 \item{object}{policy_tree object}
@@ -12,14 +12,14 @@
 \item{newdata}{A data frame with features}
 
 \item{type}{The type of prediction required, "action" is the action id and
-"leaf" is the integer id of the leaf node the samples falls into. Default is "action".}
+"node.id" is the integer id of the leaf node the samples falls into. Default is "action".}
 
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-A vector of predictions. For type = "action" each element is an integer from 1 to d where d is
-the number of columns in the reward matrix. For type = "leaf" each element is an integer corresponding
-to the node id the sample falls into.
+A vector of predictions. For type = "action.id" each element is an integer from 1 to d where d is
+the number of columns in the reward matrix. For type = "node.id" each element is an integer corresponding
+to the node the sample falls into.
 }
 \description{
 Predict values based on fitted policy_tree object.
@@ -44,9 +44,9 @@ tree
 predicted <- predict(tree, X)
 
 # Predict the leaf assigned to each sample.
-leaf.id <- predict(tree, X, type = "leaf")
+node.id <- predict(tree, X, type = "node.id")
 # Reshape to a list of samples per leaf node with `split`.
-samples.per.leaf <- split(1:n, leaf.id)
+samples.per.leaf <- split(1:n, node.id)
 
 plot(X[, 1], X[, 2], col = predicted)
 legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -4,18 +4,22 @@
 \alias{predict.policy_tree}
 \title{Predict method for policy_tree}
 \usage{
-\method{predict}{policy_tree}(object, newdata, ...)
+\method{predict}{policy_tree}(object, newdata, type = c("action", "leaf"), ...)
 }
 \arguments{
 \item{object}{policy_tree object}
 
 \item{newdata}{A data frame with features}
 
+\item{type}{The type of prediction required, "action" is the action id and
+"leaf" is the integer id of the leaf node the samples falls into. Default is "action".}
+
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-A vector of predictions. Each element is an integer from 1 to d where d is
-the number of columns in the reward matrix.
+A vector of predictions. For type = "action" each element is an integer from 1 to d where d is
+the number of columns in the reward matrix. For type = "leaf" each element is an integer from
+1 to the number of leaves.
 }
 \description{
 Predict values based on fitted policy_tree object.
@@ -38,6 +42,11 @@ tree
 
 # Predict treatment assignment.
 predicted <- predict(tree, X)
+
+# Predict the leaf assigned to each sample.
+leaf.id <- predict(tree, X, type = "leaf")
+# Reshape to a list of samples per leaf node with `split`.
+samples.per.leaf <- split(1:n, leaf.id)
 
 plot(X[, 1], X[, 2], col = predicted)
 legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)

--- a/r-package/policytree/src/RcppExports.cpp
+++ b/r-package/policytree/src/RcppExports.cpp
@@ -20,7 +20,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // tree_search_rcpp_predict
-Rcpp::NumericVector tree_search_rcpp_predict(const Rcpp::NumericMatrix& tree_array, const Rcpp::NumericMatrix& X);
+Rcpp::NumericMatrix tree_search_rcpp_predict(const Rcpp::NumericMatrix& tree_array, const Rcpp::NumericMatrix& X);
 RcppExport SEXP _policytree_tree_search_rcpp_predict(SEXP tree_arraySEXP, SEXP XSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/r-package/policytree/src/Rcppbindings.cpp
+++ b/r-package/policytree/src/Rcppbindings.cpp
@@ -100,7 +100,7 @@ Rcpp::List tree_search_rcpp(const Rcpp::NumericMatrix& X,
 }
 
 /**
-  * Return the action index for query samples.
+  * Return a matrix with (action index, node id) for query samples.
   *
   * @param tree_array The tree.
   * @param X The query samples.
@@ -108,17 +108,18 @@ Rcpp::List tree_search_rcpp(const Rcpp::NumericMatrix& X,
   *
   */
 // [[Rcpp::export]]
-Rcpp::NumericVector tree_search_rcpp_predict(const Rcpp::NumericMatrix& tree_array,
+Rcpp::NumericMatrix tree_search_rcpp_predict(const Rcpp::NumericMatrix& tree_array,
                                              const Rcpp::NumericMatrix& X) {
   size_t num_samples = X.rows();
-  Rcpp::NumericVector result(num_samples);
+  Rcpp::NumericMatrix result(num_samples, 2);
   for (size_t sample = 0; sample < num_samples; sample++) {
     size_t node = 0;
     while (true) {
       bool is_leaf = tree_array(node, 0) == -1;
       if (is_leaf) {
         size_t action = tree_array(node, 1);
-        result(sample) = action;
+        result(sample, 0) = action;
+        result(sample, 1) = node;
         break;
       }
       size_t split_var = tree_array(node, 0) - 1; // Offset by 1 for C++ indexing

--- a/r-package/policytree/tests/testthat/test_policy_tree.R
+++ b/r-package/policytree/tests/testthat/test_policy_tree.R
@@ -352,7 +352,7 @@ test_that("leaf id predictions work as expected", {
   Y <- matrix(0, n, d)
 
   tree <- policy_tree(X, Y, depth = depth)
-  leaf.id <- predict(tree, X, type = "leaf")
+  leaf.id <- predict(tree, X, type = "node.id")
 
   expect_equal(leaf.id, rep(0, n))
 })

--- a/r-package/policytree/tests/testthat/test_policy_tree.R
+++ b/r-package/policytree/tests/testthat/test_policy_tree.R
@@ -354,5 +354,5 @@ test_that("leaf id predictions work as expected", {
   tree <- policy_tree(X, Y, depth = depth)
   leaf.id <- predict(tree, X, type = "leaf")
 
-  expect_equal(leaf.id, rep(1, n))
+  expect_equal(leaf.id, rep(0, n))
 })

--- a/r-package/policytree/tests/testthat/test_policy_tree.R
+++ b/r-package/policytree/tests/testthat/test_policy_tree.R
@@ -342,3 +342,17 @@ test_that("tree search with approximate splitting on data with low cardinality w
 
   expect_equal(reward, best.reward, tol = 0.05)
 })
+
+test_that("leaf id predictions work as expected", {
+  depth <- 2
+  n <- 250
+  p <- 5
+  d <- 3
+  X <- matrix(rnorm(n * p), n, p)
+  Y <- matrix(0, n, d)
+
+  tree <- policy_tree(X, Y, depth = depth)
+  leaf.id <- predict(tree, X, type = "leaf")
+
+  expect_equal(leaf.id, rep(1, n))
+})


### PR DESCRIPTION
Add a new argument to `predict` which returns the leaf node the sample falls into.

```R
action.id <- predict(tree, X)
leaf.id <- predict(tree, X, type = "node.id")
# samples per leaf.id
summary(as.factor(leaf.id))
#   3   4   5   6 
# 154 155 138  53 
```