### PR TITLE
Update docstring with example use case for node.id prediction

### DIFF
--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -59,7 +59,7 @@
 #'
 #' # Predict the leaf assigned to each sample.
 #' node.id <- predict(tree, X, type = "node.id")
-#' # Can be reshape to a list of samples per leaf node with `split`.
+#' # Can be reshaped to a list of samples per leaf node with `split`.
 #' samples.per.leaf <- split(1:n, node.id)
 #'
 #' # The value of all arms (along with SEs) by each leaf node.
@@ -168,7 +168,7 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1) 
 #'
 #' # Predict the leaf assigned to each sample.
 #' node.id <- predict(tree, X, type = "node.id")
-#' # Can be reshape to a list of samples per leaf node with `split`.
+#' # Can be reshaped to a list of samples per leaf node with `split`.
 #' samples.per.leaf <- split(1:n, node.id)
 #'
 #' # The value of all arms (along with SEs) by each leaf node.

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -53,14 +53,19 @@
 #' # Predict treatment assignment.
 #' predicted <- predict(tree, X)
 #'
-#' # Predict the leaf assigned to each sample.
-#' node.id <- predict(tree, X, type = "node.id")
-#' # Reshape to a list of samples per leaf node with `split`.
-#' samples.per.leaf <- split(1:n, node.id)
-#'
 #' plot(X[, 1], X[, 2], col = predicted)
 #' legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
 #' abline(0, -1, lty = 2)
+#'
+#' # Predict the leaf assigned to each sample.
+#' node.id <- predict(tree, X, type = "node.id")
+#' # Can be reshape to a list of samples per leaf node with `split`.
+#' samples.per.leaf <- split(1:n, node.id)
+#'
+#' # The value of all arms (along with SEs) by each leaf node.
+#' values <- aggregate(dr.scores, by = list(leaf.node = node.id),
+#'                     FUN = function(x) c(mean = mean(x), se = sd(x) / sqrt(length(x))))
+#' print(values, digits = 2)
 #' }
 #' @export
 #' @importFrom utils type.convert
@@ -157,14 +162,19 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1) 
 #' # Predict treatment assignment.
 #' predicted <- predict(tree, X)
 #'
-#' # Predict the leaf assigned to each sample.
-#' node.id <- predict(tree, X, type = "node.id")
-#' # Reshape to a list of samples per leaf node with `split`.
-#' samples.per.leaf <- split(1:n, node.id)
-#'
 #' plot(X[, 1], X[, 2], col = predicted)
 #' legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
 #' abline(0, -1, lty = 2)
+#'
+#' # Predict the leaf assigned to each sample.
+#' node.id <- predict(tree, X, type = "node.id")
+#' # Can be reshape to a list of samples per leaf node with `split`.
+#' samples.per.leaf <- split(1:n, node.id)
+#'
+#' # The value of all arms (along with SEs) by each leaf node.
+#' values <- aggregate(dr.scores, by = list(leaf.node = node.id),
+#'                     FUN = function(x) c(mean = mean(x), se = sd(x) / sqrt(length(x))))
+#' print(values, digits = 2)
 #' }
 predict.policy_tree <- function(object, newdata, type = c("action.id", "node.id"), ...) {
   type <- match.arg(type)

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -60,14 +60,19 @@ tree
 # Predict treatment assignment.
 predicted <- predict(tree, X)
 
-# Predict the leaf assigned to each sample.
-node.id <- predict(tree, X, type = "node.id")
-# Reshape to a list of samples per leaf node with `split`.
-samples.per.leaf <- split(1:n, node.id)
-
 plot(X[, 1], X[, 2], col = predicted)
 legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
 abline(0, -1, lty = 2)
+
+# Predict the leaf assigned to each sample.
+node.id <- predict(tree, X, type = "node.id")
+# Can be reshape to a list of samples per leaf node with `split`.
+samples.per.leaf <- split(1:n, node.id)
+
+# The value of all arms (along with SEs) by each leaf node.
+values <- aggregate(dr.scores, by = list(leaf.node = node.id),
+                    FUN = function(x) c(mean = mean(x), se = sd(x) / sqrt(length(x))))
+print(values, digits = 2)
 }
 }
 \references{

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -66,7 +66,7 @@ abline(0, -1, lty = 2)
 
 # Predict the leaf assigned to each sample.
 node.id <- predict(tree, X, type = "node.id")
-# Can be reshape to a list of samples per leaf node with `split`.
+# Can be reshaped to a list of samples per leaf node with `split`.
 samples.per.leaf <- split(1:n, node.id)
 
 # The value of all arms (along with SEs) by each leaf node.

--- a/r-package/policytree/man/policytree-package.Rd
+++ b/r-package/policytree/man/policytree-package.Rd
@@ -43,6 +43,7 @@ predict(opt.tree, X[-train, ])
 Useful links:
 \itemize{
   \item \url{https://github.com/grf-labs/policytree}
+  \item Report bugs at \url{https://github.com/grf-labs/policytree/issues}
 }
 
 }

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -49,7 +49,7 @@ abline(0, -1, lty = 2)
 
 # Predict the leaf assigned to each sample.
 node.id <- predict(tree, X, type = "node.id")
-# Can be reshape to a list of samples per leaf node with `split`.
+# Can be reshaped to a list of samples per leaf node with `split`.
 samples.per.leaf <- split(1:n, node.id)
 
 # The value of all arms (along with SEs) by each leaf node.

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -43,13 +43,18 @@ tree
 # Predict treatment assignment.
 predicted <- predict(tree, X)
 
-# Predict the leaf assigned to each sample.
-node.id <- predict(tree, X, type = "node.id")
-# Reshape to a list of samples per leaf node with `split`.
-samples.per.leaf <- split(1:n, node.id)
-
 plot(X[, 1], X[, 2], col = predicted)
 legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
 abline(0, -1, lty = 2)
+
+# Predict the leaf assigned to each sample.
+node.id <- predict(tree, X, type = "node.id")
+# Can be reshape to a list of samples per leaf node with `split`.
+samples.per.leaf <- split(1:n, node.id)
+
+# The value of all arms (along with SEs) by each leaf node.
+values <- aggregate(dr.scores, by = list(leaf.node = node.id),
+                    FUN = function(x) c(mean = mean(x), se = sd(x) / sqrt(length(x))))
+print(values, digits = 2)
 }
 }


### PR DESCRIPTION
Predicting the leaf node (#78) is a useful option (thanks @halflearned) - adding one intended use case in the docstring here.

Another more advanced use-case could be to repopulate leaves in a new test sample, and compute "honest" actions with this tree. Leaving that as feature request for now (i.e. `new.tree <- repopulate_leaves(old.tree, X, Y)`, if that is ok with @halflearned (maybe we could have an issue for that)