### PR TITLE
Return R-indexed node.id

### DIFF
--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -139,7 +139,7 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1) 
 #'
 #' @return A vector of predictions. For type = "action.id" each element is an integer from 1 to d where d is
 #'  the number of columns in the reward matrix. For type = "node.id" each element is an integer corresponding
-#'  to the node the sample falls into.
+#'  to the node the sample falls into (level-ordered).
 #' @export
 #'
 #' @method predict policy_tree

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -200,7 +200,7 @@ predict.policy_tree <- function(object, newdata, type = c("action.id", "node.id"
   if (type == "action.id") {
     return (ret[, 1])
   } else {
-    return (ret[, 2])
+    return (ret[, 2] + 1) # + 1 for R-index.
   }
 
 }

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -19,7 +19,7 @@
 \value{
 A vector of predictions. For type = "action.id" each element is an integer from 1 to d where d is
 the number of columns in the reward matrix. For type = "node.id" each element is an integer corresponding
-to the node the sample falls into.
+to the node the sample falls into (level-ordered).
 }
 \description{
 Predict values based on fitted policy_tree object.

--- a/r-package/policytree/tests/testthat/test_policy_tree.R
+++ b/r-package/policytree/tests/testthat/test_policy_tree.R
@@ -356,7 +356,7 @@ test_that("leaf id predictions work as expected", {
   tree <- policy_tree(X, Y, depth = depth)
   leaf.id <- predict(tree, X, type = "node.id")
 
-  expect_equal(leaf.id, rep(0, n))
+  expect_equal(leaf.id, rep(1, n))
 })
 
 test_that("min.node.size works as expected", {


### PR DESCRIPTION
The tree is printed with R-indexed node numbers, so the prediction returns should be 1-indexed too.

(DiagrammeR's hover-over node id prints 0-indexed in plots. We stick with R-indexing for consistency).

```
> n <- 25
> p <- 5
> d <- 3
> X <- matrix(runif(n * p), n, p)
> Y <- matrix(rnorm(n * d), n, d)
> tree <- policy_tree(X, Y, depth = 2)
> tree
policy_tree object 
Tree depth:  2 
Actions:  1 2 3 
Variable splits: 
(1) split_variable: X3  split_value: 0.832141 
  (2) split_variable: X3  split_value: 0.507951 
    (4) * action: 2 
    (5) * action: 1 
  (3) split_variable: X3  split_value: 0.868828 
    (6) * action: 2 
    (7) * action: 3 
> predict(tree, X, type = "node.id")
 [1] 4 4 6 7 5 7 5 5 5 6 6 5 7 4 4 5 6 7 4 4 5 4 5 4 4
```