### PR TITLE
Minor amendments for GRF 2.0

### DIFF
--- a/r-package/policytree/R/multi_causal_forest.R
+++ b/r-package/policytree/R/multi_causal_forest.R
@@ -120,7 +120,7 @@ multi_causal_forest <- function(X, Y, W,
                                 num.threads = NULL,
                                 seed = runif(1, 0, .Machine$integer.max)) {
   warning(paste0("\nDeprecation warning:\n",
-                 "This forest is going to be removed in an upcoming major version in favor of ",
+                 "This forest is deprecated in favor of ",
                  "the new estimator `multi_arm_causal_forest` available in GRF 2.0. ",
                  "(details: https://grf-labs.github.io/grf/reference/multi_arm_causal_forest.html)."))
   if (!inherits(X, c("matrix", "data.frame"))) {

--- a/r-package/policytree/R/multi_causal_forest.R
+++ b/r-package/policytree/R/multi_causal_forest.R
@@ -73,6 +73,7 @@
 #' @param tune.num.draws The number of random parameter values considered when using the model
 #'                          to select the optimal parameters. Default is 1000.
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
+#' @param orthog.boosting Deprecated and unused after version 1.0.4.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
@@ -117,6 +118,7 @@ multi_causal_forest <- function(X, Y, W,
                                 tune.num.reps = 50,
                                 tune.num.draws = 1000,
                                 compute.oob.predictions = TRUE,
+                                orthog.boosting = FALSE,
                                 num.threads = NULL,
                                 seed = runif(1, 0, .Machine$integer.max)) {
   warning(paste0("\nDeprecation warning:\n",

--- a/r-package/policytree/R/multi_causal_forest.R
+++ b/r-package/policytree/R/multi_causal_forest.R
@@ -73,9 +73,6 @@
 #' @param tune.num.draws The number of random parameter values considered when using the model
 #'                          to select the optimal parameters. Default is 1000.
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
-#' @param orthog.boosting (experimental) If TRUE, then when Y.hat = NULL or W.hat is NULL,
-#'                 the missing quantities are estimated using boosted regression forests.
-#'                 The number of boosting steps is selected automatically. Default is FALSE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
@@ -120,7 +117,6 @@ multi_causal_forest <- function(X, Y, W,
                                 tune.num.reps = 50,
                                 tune.num.draws = 1000,
                                 compute.oob.predictions = TRUE,
-                                orthog.boosting = FALSE,
                                 num.threads = NULL,
                                 seed = runif(1, 0, .Machine$integer.max)) {
   warning(paste0("\nDeprecation warning:\n",
@@ -158,11 +154,8 @@ multi_causal_forest <- function(X, Y, W,
                      num.threads = num.threads,
                      seed = seed)
 
-  if (is.null(Y.hat) && !orthog.boosting) {
+  if (is.null(Y.hat)) {
     forest.Y <- do.call(grf::regression_forest, c(Y = list(Y), args.orthog))
-    Y.hat <- predict(forest.Y)$predictions
-  } else if (is.null(Y.hat) && orthog.boosting) {
-    forest.Y <- do.call(grf::boosted_regression_forest, c(Y = list(Y), args.orthog))
     Y.hat <- predict(forest.Y)$predictions
   } else if (length(Y.hat) == 1) {
     Y.hat <- rep(Y.hat, nrow(X))
@@ -173,17 +166,10 @@ multi_causal_forest <- function(X, Y, W,
   # Propensities
   W.onevsall <- sapply(treatments, function(treatment) as.integer(W == treatment))
   if (is.null(W.hat)) {
-    if (!orthog.boosting) {
-      W.hat <- apply(W.onevsall, 2, function(Wi) {
-        forest.W <- do.call(grf::regression_forest, c(Y = list(Wi), args.orthog))
-        predict(forest.W)$predictions
-      })
-    } else if (orthog.boosting) {
-      W.hat <- apply(W.onevsall, 2, function(Wi) {
-        forest.W <- do.call(grf::boosted_regression_forest, c(Y = list(Wi), args.orthog))
-        predict(forest.W)$predictions
-      })
-    }
+    W.hat <- apply(W.onevsall, 2, function(Wi) {
+      forest.W <- do.call(grf::regression_forest, c(Y = list(Wi), args.orthog))
+      predict(forest.W)$predictions
+    })
     # Normalize to sum to 1
     W.hat <- sweep(W.hat, 1, rowSums(W.hat), `/`)
   } else if (length(W.hat) == n.treatments) {
@@ -214,7 +200,6 @@ multi_causal_forest <- function(X, Y, W,
                        tune.num.trees = tune.num.trees,
                        tune.num.reps = tune.num.reps,
                        compute.oob.predictions = compute.oob.predictions,
-                       orthog.boosting = FALSE,
                        num.threads = num.threads,
                        seed = seed)
   })

--- a/r-package/policytree/R/multi_causal_forest.R
+++ b/r-package/policytree/R/multi_causal_forest.R
@@ -123,9 +123,9 @@ multi_causal_forest <- function(X, Y, W,
                  "This forest is going to be removed in an upcoming major version in favor of ",
                  "the new estimator `multi_arm_causal_forest` available in GRF 2.0. ",
                  "(details: https://grf-labs.github.io/grf/reference/multi_arm_causal_forest.html)."))
-  if (!inherits(X, c("matrix", "data.frame", "dgCMatrix"))) {
+  if (!inherits(X, c("matrix", "data.frame"))) {
     stop(paste("Currently the only supported data input types are:",
-               "`matrix`, `data.frame`, `dgCMatrix`"))
+               "`matrix`, `data.frame`"))
   }
   if (length(W) != nrow(X) || any(is.na(W))) {
     stop("Invalid W input.")

--- a/r-package/policytree/man/multi_causal_forest.Rd
+++ b/r-package/policytree/man/multi_causal_forest.Rd
@@ -29,7 +29,6 @@ multi_causal_forest(
   tune.num.reps = 50,
   tune.num.draws = 1000,
   compute.oob.predictions = TRUE,
-  orthog.boosting = FALSE,
   num.threads = NULL,
   seed = runif(1, 0, .Machine$integer.max)
 )
@@ -122,10 +121,6 @@ Default is "none" (no parameters are tuned).}
 to select the optimal parameters. Default is 1000.}
 
 \item{compute.oob.predictions}{Whether OOB predictions on training set should be precomputed. Default is TRUE.}
-
-\item{orthog.boosting}{(experimental) If TRUE, then when Y.hat = NULL or W.hat is NULL,
-the missing quantities are estimated using boosted regression forests.
-The number of boosting steps is selected automatically. Default is FALSE.}
 
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}

--- a/r-package/policytree/man/multi_causal_forest.Rd
+++ b/r-package/policytree/man/multi_causal_forest.Rd
@@ -29,6 +29,7 @@ multi_causal_forest(
   tune.num.reps = 50,
   tune.num.draws = 1000,
   compute.oob.predictions = TRUE,
+  orthog.boosting = FALSE,
   num.threads = NULL,
   seed = runif(1, 0, .Machine$integer.max)
 )
@@ -121,6 +122,8 @@ Default is "none" (no parameters are tuned).}
 to select the optimal parameters. Default is 1000.}
 
 \item{compute.oob.predictions}{Whether OOB predictions on training set should be precomputed. Default is TRUE.}
+
+\item{orthog.boosting}{Deprecated and unused after version 1.0.4.}
 
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}

--- a/r-package/policytree/tests/testthat/test_multi_causal_forest.R
+++ b/r-package/policytree/tests/testthat/test_multi_causal_forest.R
@@ -13,7 +13,7 @@ test_that("everything runs", {
   double_robust_scores(mcf)
   p <- capture.output(print(mcf))
 
-  expect_warning(multi_causal_forest(X, Y, W, orthog.boosting = TRUE))
+  expect_warning(multi_causal_forest(X, Y, W))
 
   expect_warning(multi_causal_forest(X, Y, W, W.hat = c(1 / 3, 1 / 3, 1 / 3)))
 


### PR DESCRIPTION
`multi_causal_forest`: disable `orthog.boosting` arg and `dgCMatrix` input. 