### PR TITLE
Add "high cardinality" warning to tree search

### DIFF
--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -27,6 +27,7 @@
 #'  problem specific manner allows for finer-grained control of the accuracy/runtime tradeoff and may in some cases
 #'  be the preferred approach.
 #' @param min.node.size An integer indicating the smallest terminal node size permitted. Default is 1.
+#' @param verbose Give verbose output. Default is TRUE.
 #'
 #' @return A policy_tree object.
 #'
@@ -87,7 +88,7 @@
 #' tree.top5 <- policy_tree(X[, top.5], dr.scores, 2, split.step = 50)
 #' }
 #' @export
-policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1) {
+policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1, verbose = TRUE) {
   n.features <- ncol(X)
   n.actions <- ncol(Gamma)
   n.obs <- nrow(X)
@@ -120,6 +121,19 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1) 
   }
   if (as.integer(min.node.size) != min.node.size || min.node.size < 1) {
     stop("min.node.size should be an integer greater than or equal to 1.")
+  }
+
+  if (verbose) {
+    cardinality <- apply(X, 2, function(x) length(unique(x)))
+    if (any(cardinality > 20000)) {
+      warning(paste0(
+        "The cardinality of some covariates exceeds 20000 distinct values. ",
+        "Consider using the optional parameter `split.step` to speed up computations, or ",
+        "discretize/relabel continuous features for finer grained control ",
+        "(the runtime of exact tree search scales with the number of distinct features, ",
+        "see the documentation for details.)"
+      ), immediate. = TRUE)
+    }
   }
 
   action.names <- colnames(Gamma)

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -44,7 +44,7 @@
 #' # Fit a depth two tree on doubly robust treatment effect estimates from a causal forest.
 #' n <- 10000
 #' p <- 10
-#' # Rounding down continuous covariates decreases runtime.
+#' # Discretizing continuous covariates decreases runtime.
 #' X <- round(matrix(rnorm(n * p), n, p), 2)
 #' colnames(X) <- make.names(1:p)
 #' W <- rbinom(n, 1, 1 / (1 + exp(X[, 3])))
@@ -181,7 +181,7 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1, 
 #' # Fit a depth two tree on doubly robust treatment effect estimates from a causal forest.
 #' n <- 10000
 #' p <- 10
-#' # Rounding down continuous covariates decreases runtime.
+#' # Discretizing continuous covariates decreases runtime.
 #' X <- round(matrix(rnorm(n * p), n, p), 2)
 #' colnames(X) <- make.names(1:p)
 #' W <- rbinom(n, 1, 1 / (1 + exp(X[, 3])))

--- a/r-package/policytree/R/policy_tree.R
+++ b/r-package/policytree/R/policy_tree.R
@@ -125,7 +125,7 @@ policy_tree <- function(X, Gamma, depth = 2, split.step = 1, min.node.size = 1, 
 
   if (verbose) {
     cardinality <- apply(X, 2, function(x) length(unique(x)))
-    if (any(cardinality > 20000)) {
+    if (any(cardinality > 20000) && split.step == 1) {
       warning(paste0(
         "The cardinality of some covariates exceeds 20000 distinct values. ",
         "Consider using the optional parameter `split.step` to speed up computations, or ",

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -58,7 +58,7 @@ and it is therefore beneficial to round down/re-encode very dense data to a lowe
 # Fit a depth two tree on doubly robust treatment effect estimates from a causal forest.
 n <- 10000
 p <- 10
-# Rounding down continuous covariates decreases runtime.
+# Discretizing continuous covariates decreases runtime.
 X <- round(matrix(rnorm(n * p), n, p), 2)
 colnames(X) <- make.names(1:p)
 W <- rbinom(n, 1, 1 / (1 + exp(X[, 3])))

--- a/r-package/policytree/man/policy_tree.Rd
+++ b/r-package/policytree/man/policy_tree.Rd
@@ -4,7 +4,14 @@
 \alias{policy_tree}
 \title{Fit a policy with exact tree search}
 \usage{
-policy_tree(X, Gamma, depth = 2, split.step = 1, min.node.size = 1)
+policy_tree(
+  X,
+  Gamma,
+  depth = 2,
+  split.step = 1,
+  min.node.size = 1,
+  verbose = TRUE
+)
 }
 \arguments{
 \item{X}{The covariates used. Dimension \eqn{N*p} where \eqn{p} is the number of features.}
@@ -21,6 +28,8 @@ problem specific manner allows for finer-grained control of the accuracy/runtime
 be the preferred approach.}
 
 \item{min.node.size}{An integer indicating the smallest terminal node size permitted. Default is 1.}
+
+\item{verbose}{Give verbose output. Default is TRUE.}
 }
 \value{
 A policy_tree object.

--- a/r-package/policytree/man/predict.policy_tree.Rd
+++ b/r-package/policytree/man/predict.policy_tree.Rd
@@ -30,7 +30,7 @@ Predict values based on fitted policy_tree object.
 # Fit a depth two tree on doubly robust treatment effect estimates from a causal forest.
 n <- 10000
 p <- 10
-# Rounding down continuous covariates decreases runtime.
+# Discretizing continuous covariates decreases runtime.
 X <- round(matrix(rnorm(n * p), n, p), 2)
 colnames(X) <- make.names(1:p)
 W <- rbinom(n, 1, 1 / (1 + exp(X[, 3])))


### PR DESCRIPTION
Add a new  optional `verbose = TRUE` flag to `tree_search` which prints an informative message in case the input cardinality is "high".