### PR TITLE
Revert "Predict same leaf labels as printed labels with hybrid policy tree"

### DIFF
--- a/r-package/policytree/R/hybrid_policy_tree.R
+++ b/r-package/policytree/R/hybrid_policy_tree.R
@@ -181,7 +181,7 @@ unpack_tree <- function(tree) {
 # The 5th column is just the node label according to the print() order a hybrid tree has.
 tree_mat <- function(nodes, depth) {
   num.nodes <- 2^(depth + 1) - 1
-  tree.array <- matrix(0, num.nodes, 5)
+  tree.array <- matrix(0, num.nodes, 4)
   frontier <- 1
   i <- 1
   j <- 1
@@ -191,13 +191,11 @@ tree_mat <- function(nodes, depth) {
     if (nodes[[node]]$is_leaf) {
       tree.array[j, 1] <- -1
       tree.array[j, 2] <- nodes[[node]]$action
-      tree.array[j, 5] <- node - 1
     } else {
       tree.array[j, 1] <- nodes[[node]]$split_variable
       tree.array[j, 2] <- nodes[[node]]$split_value
       tree.array[j, 3] <- i + 1
       tree.array[j, 4] <- i + 2
-      tree.array[j, 5] <- node - 1
       frontier <- c(frontier, nodes[[node]]$left_child, nodes[[node]]$right_child)
       i <- i + 2
     }

--- a/r-package/policytree/tests/testthat/test_hybrid_policy_tree.R
+++ b/r-package/policytree/tests/testthat/test_hybrid_policy_tree.R
@@ -1,7 +1,7 @@
 test_that("hybrid_policy_tree works as expected", {
   n <- 500
   p <- 2
-  d <- 42
+  d <- 2
   X <- round(matrix(rnorm(n * p), n, p), 1)
   Y <- matrix(runif(n * d), n, d)
 
@@ -25,17 +25,6 @@ test_that("hybrid_policy_tree works as expected", {
     }
   }
   expect_equal(hpp, pp)
-  # is internally consistent with predicted node ids.
-  hpp.node <- predict(htree, X, type = "node.id")
-  values <- aggregate(Y, by = list(leaf.node = hpp.node), FUN = mean)
-  best <- apply(values[, -1], 1, FUN = which.max)
-  expect_equal(best[match(hpp.node, values[, 1])], hpp)
-
-  # uses node labels that are the same as the printed labels.
-  printed.node.id <- lapply(seq_along(htree$nodes), function(i) {
-    if (htree$nodes[[i]]$is_leaf) i
-  })
-  expect_true(all(unique(hpp.node) %in% printed.node.id))
 
   # search.depth = 1 when a single split is optimal is identical to a depth 1 policy_tree
   n <- 250


### PR DESCRIPTION
Do a better fix of this by instead updating the printed leaf labels of hybrid policytree. 