### PR TITLE
Drop CXX_STD in Makevars

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
     condition: eq(variables['Agent.OS'], 'Linux')
   - script: |
       echo CXX_STD = $(cppVer) >> Makevars
-    workingDirectory: r-package/grf/bindings
+    workingDirectory: r-package/policytree/src
     displayName: Specify CXX_STD in R Makevars
     condition: ne(variables['Agent.OS'], 'Linux')
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,10 @@ jobs:
         imageName: "ubuntu-latest"
       macos:
         imageName: "macOS-latest"
+        cppVer: "CXX20"
+      macos_cpp11:
+        imageName: "macOS-latest"
+        cppVer: "CXX11"
   pool:
     vmImage: $(imageName)
 
@@ -36,6 +40,11 @@ jobs:
       sudo apt-get install -qq valgrind
     displayName: Setup valgrind
     condition: eq(variables['Agent.OS'], 'Linux')
+  - script: |
+      echo CXX_STD = $(cppVer) >> Makevars
+    workingDirectory: r-package/grf/bindings
+    displayName: Specify CXX_STD in R Makevars
+    condition: ne(variables['Agent.OS'], 'Linux')
   - script: |
       curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
       ./run.sh bootstrap

--- a/r-package/policytree/src/Makevars
+++ b/r-package/policytree/src/Makevars
@@ -1,2 +1,0 @@
-## Use c++11
-CXX_STD = CXX11


### PR DESCRIPTION
Drop CXX=C++11 per latest CRAN, but add a test in CI to ensure policytree continues compiling with with C++11 and up.