### PR TITLE
Move pages to github actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,6 @@ name: Deploy gh-pages
 on:
   push:
     branches: ["master"]
-  pull_request:
-    branches: master
 
   workflow_dispatch:
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy gh-pages
 on:
   push:
     branches: ["master"]
+  pull_request:
+    branches: master
 
   workflow_dispatch:
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,8 +31,7 @@ jobs:
           sudo apt-get install -qq pandoc
 
           # Install R
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
-          chmod 0755 run.sh
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
           ./run.sh bootstrap
           ./run.sh install_all
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy gh-pages
+
+on:
+  push:
+    branches: ["master"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build docs
+        working-directory: r-package/policytree
+        run: |
+          # Install pandoc
+          sudo apt-get install -qq pandoc
+
+          # Install R
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          chmod 0755 run.sh
+          ./run.sh bootstrap
+          ./run.sh install_all
+
+          # Install policytree
+          R CMD INSTALL .
+
+          # Use pkgdown v1.5
+          sudo Rscript -e "install.packages(c('fs', 'highlight', 'httr', 'memoise', 'openssl', 'purrr', 'rmarkdown', 'rstudioapi', 'whisker', 'xml2', 'yaml'))"
+          sudo Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/pkgdown/pkgdown_1.5.1.tar.gz', repos = NULL, type = 'source')"
+
+          # Build site
+          cp ../../README.md .
+          cp ../../releases/CHANGELOG.md .
+          Rscript -e "pkgdown::build_site()"
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'r-package/policytree/docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,35 +65,3 @@ jobs:
     workingDirectory: r-package/policytree
     displayName: Valgrind check
     condition: eq(variables['Agent.OS'], 'Linux')
-  # Final deploy step
-  # Build the online docs and deploy to gh-pages - only done on master branch with Linux image.
-  # `GITHUB_PAT` is a GitHub access token stored on Azure Pipelines.
-  - script: |
-      set -e
-      sudo apt-get install -qq pandoc
-      # Lock in a previous version of `pkgdown` and its dependencies.
-      sudo Rscript -e "install.packages(c('fs', 'highlight', 'httr', 'memoise', 'openssl', 'purrr', 'rmarkdown', 'rstudioapi', 'whisker', 'xml2', 'yaml'))"
-      sudo Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/pkgdown/pkgdown_1.5.1.tar.gz', repos = NULL, type = 'source')"
-      # Install dependencies needed for vignettes.
-      sudo Rscript -e "install.packages(c('DiagrammeR'))"
-      cp ../../README.md .
-      cp ../../releases/CHANGELOG.md .
-      # Build and deploy page. This requires that the branch `gh-pages` exists.
-      # git worktree is used to only commit the doc folder (docs/) as the root.
-      # update-ref is used to not keep a commit history of the generated docs.
-      git config --local user.email "azuredevops@microsoft.com"
-      git config --local user.name "Azure Pipelines"
-      git worktree add -B gh-pages docs/ origin/gh-pages
-      rm -rf docs/*
-      Rscript -e "pkgdown::build_site()"
-      cd docs
-      git add --all
-      git update-ref -d refs/heads/gh-pages
-      git commit --allow-empty -m "Update gh-pages ***NO_CI***"
-      git push --force https://$(GITHUB_PAT)@github.com/grf-labs/policytree.git HEAD:gh-pages
-    workingDirectory: r-package/policytree
-    displayName: 'Publish GitHub Pages'
-    condition: |
-      and(eq(variables['Agent.OS'], 'Linux'),
-      and(not(eq(variables['Build.Reason'], 'PullRequest')),
-      eq(variables['Build.SourceBranch'], 'refs/heads/master')))


### PR DESCRIPTION
Address some github deprecations and deploy gh-pages using actions:

>After June 30, 2024, Pages sites will require GitHub Actions for the Jekyll build step. To prevent any disruption, please enable GitHub Actions for this repository
